### PR TITLE
Only log HTTP traffic and info level logs when in Debug mode

### DIFF
--- a/application/application.go
+++ b/application/application.go
@@ -58,8 +58,16 @@ func LoadFromConfig(cfg *config.Config) (context.Context, error) {
 		DefaultQuality: cfg.Options.Quality,
 	}
 
+	log := logrus.New()
+
+	if cfg.Debug {
+		log.Level = logrus.DebugLevel
+	} else {
+		log.Level = logrus.ErrorLevel
+	}
+
 	ctx = engine.NewContext(ctx, e)
-	ctx = logger.NewContext(ctx, logrus.New())
+	ctx = logger.NewContext(ctx, log)
 
 	return ctx, nil
 }

--- a/server/server.go
+++ b/server/server.go
@@ -35,9 +35,14 @@ func Load(path string) error {
 
 // Router returns a gin Engine
 func Router(ctx netContext.Context) (*gin.Engine, error) {
-	router := gin.Default()
+	router := gin.New()
+	router.Use(gin.Recovery())
 
 	cfg := config.FromContext(ctx)
+
+	if cfg.Debug {
+		router.Use(gin.Logger())
+	}
 
 	methods := map[string]gin.HandlerFunc{
 		"redirect": views.RedirectView,


### PR DESCRIPTION
This disables Gin HTTP logging when debug mode is disabled, and will limit the log level of logrus to Error and lower.

It's important to note that Picfit wrote logging from two sources **logrus**, which is a logging library, and **Gin** which is the router library that by default was attaching a middleware logger that writes to std out.

**Why don't we also log >400 responses?**

I wanted to log responses that fell within the 4xx or 5xx range using the original gin logger, but it's actually a little bit tricky to do.

The gin logger is constructed using the [this handler](https://github.com/gin-gonic/gin/blob/38e4b1d2fe5b0890dd2f72def7d5852b4a25984f/logger.go#L66-L100). Unfortunately we're unable to wrap this as it actually executes the request to obtain the status code.

We could more or less copy the logging code from this and implement our own logger, but I didn't want to complicate this PR even more, since I don't know if logging 4xx and 5xx (5xx will **already be logged** as they will likely be panics or have associated logrus error logging) is really that useful.

---

Once merged here, I will also open a PR to upstream.